### PR TITLE
made the top navbar smaller.

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -19,9 +19,9 @@ body, html {
   border-radius: 0px;
   position: absolute;
 }
-.navbar-brand {
-  height: 59px;
-  padding: 19px 19px;
+
+.menu {
+  font-size: 1.5em;
 }
 
 .code {
@@ -45,14 +45,14 @@ body, html {
     SIDEBAR CSS
    =================*/
 #wrapper {
-  padding-top: 59px;
+  padding-top: 50px;
   padding-left: 250px;
   transition: all 0.4s ease 0s;
 }
 
 #sidebar-wrapper {
   margin-left: -250px;
-  top: 59px;
+  top: 50px;
   left: 250px;
   width: 250px;
   background: #202c38;

--- a/index.html
+++ b/index.html
@@ -43,11 +43,11 @@
             <a class="menu" >
 
               <div class="menu-button">
-                  <i class="fa fa-bars fa-2x"></i>
+                  <i class="fa fa-bars"></i>
               </div>
 
               <div class="close-button">
-                <i class="fa fa-times fa-2x"></i>
+                <i class="fa fa-times"></i>
               </div>
 
             </a>


### PR DESCRIPTION
Deleted css needed to set the navbar to a greater height. Added css
needed to size the menu icon(s). deleted `fa-2x` classes on both
menu icons.

this results in a smaller menu/close icon and with that a smaller top
navbar. (taking up less of our precious screen space :wink:)
