### PR TITLE
fixed bottom navitem display

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -169,7 +169,7 @@ body, html {
   @media (max-width: 768px) {
       .navbar {
           border-radius: 0px;
-          min-width: 400px;
+          min-width: 100%;
       }
 
       .nav-justified > li {

--- a/index.html
+++ b/index.html
@@ -87,22 +87,17 @@
             <nav class="navbar navbar-inverse navbar-fixed-bottom">
               <div class="container-fluid">
 
-                <!--// xs only //-->
-                <ul class="nav navbar-nav hidden-sm hidden-md hidden-lg">
-                  <li id="changeMode"><a ><i class="fa fa-paint-brush fa-2x"></i></a></i></li>
-                  <li id="trash"><a> <i class="fa fa-trash fa-2x" aria-hidden="true"></i> </a></li>
-                  <li id="play" class="active"><a ><i class="fa fa-play fa-2x"></i></a></li>
-                </ul>
-                <ul class="nav navbar-nav navbar-left hidden-lg hidden-xs">
+                <!--// Hidden lg //-->
+                <ul class="nav navbar-nav navbar-left hidden-lg">
                   <li id="changeMode"><a ><i class="fa fa-paint-brush fa-2x"></i></a></i></li>
                 </ul>
-                <!--// lg only //-->
-                <ul class="nav navbar-nav navbar-right hidden-xs">
+
+                <ul class="nav navbar-nav navbar-right">
                   <li id="trash"><a ><i class="fa fa-trash fa-2x" aria-hidden="true"></i></a></li>
                   <li id="play" class="active"><a ><i class="fa fa-play fa-2x"></i></a></li>
                 </ul>
-              </div>
 
+              </div>
             </nav>
 
             <textarea id="editor"></textarea>
@@ -117,21 +112,15 @@
             <nav class="navbar navbar-inverse navbar-fixed-bottom hidden-lg">
               <div class="container-fluid">
 
-                <!--// xs only //-->
-                <ul class="nav navbar-nav hidden-sm hidden-md hidden-lg">
+                <ul class="nav navbar-nav navbar-left">
                   <li id="changeMode"><a ><i class="fa fa-code fa-2x"></i></a></i></li>
-                  <li id="play" class="active"><a ><i class="fa fa-play fa-2x"></i></a></li>
                 </ul>
 
-                <!--// hidden xs //-->
-                <ul class="nav navbar-nav navbar-left hidden-xs">
-                  <li id="changeMode"><a ><i class="fa fa-code fa-2x"></i></a></i></li>
-                </ul>
                 <ul class="nav navbar-nav navbar-right hidden-xs">
                   <li id="play" class="active"><a ><i class="fa fa-play fa-2x"></i></a></li>
                 </ul>
+                
               </div>
-
             </nav>
 
           </div>


### PR DESCRIPTION
The bottom nav items weren’t positioned right. pulling some icons right
resulted in a weird display.

This was because our nabber had a min-width of 400 on xs displays.

This has now been changed to 100% of the page width.

all the  unnecessary html has been deleted.
