### PR TITLE
Option, hide code on lg screens

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -29,11 +29,36 @@ body, html {
   height: 100%;
 }
 
+#hidden-code {
+  background-color: #202c38;
+}
+#hidden-code .navbar {
+  text-align: center;
+  width: 100%;
+}
+#hidden-code .nav{
+  float: none;
+}
+#hidden-code .nav>li {
+  float: none;
+}
+
+.table-cell {
+  display: table-cell;
+}
+
+.table {
+  width: 100%;
+  display: table;
+  max-height: 100%;
+}
+
 .output {
   /* A nice beige background */
   background-color: #FFFAED;
   /* Make the div have the height of the entire page */
   height: 100%;
+  max-height: 100%;
 }
 
 
@@ -156,7 +181,12 @@ body, html {
   }
   @media screen and (max-width: 1200px) {
     .notDisplayed {
-      display: none;
+      display: none !important;
+    }
+  }
+  @media screen and (min-width: 1200px) {
+    .hideOnLg {
+      display: none !important;
     }
   }
 

--- a/index.html
+++ b/index.html
@@ -89,28 +89,59 @@
         </ul>
       </div><!--// #sidebar-wrapper //-->
 
-      <div class="row height ">
+      <div class="row height">
+
+        <!--// This is displayed when the code editor is hidden //-->
+        <div id="hidden-code" class="col-lg-1 height notDisplayed hideOnLg">
+
+          <!--// Fixed to top navbar //-->
+          <nav class="navbar navbar-nav navbar-inverse">
+
+            <ul class="nav navbar-nav nav-stacked">
+              <li id="play" class="active"><a ><i class="fa fa-play fa-2x"></i></a></li>
+            </ul>
+
+          </nav> <!--// /top nav section //-->
+
+          <!--// Fixed to bottom navbar //-->
+          <nav class="navbar navbar-nav navbar-inverse navbar-fixed-bottom">
+
+            <ul class="nav navbar-nav nav-stacked">
+
+              <li id="toggle-code"><a> <i class="fa fa-arrow-right fa-2x"></i> </a></li>
+            </ul>
+
+          </nav> <!--// /Bottom nav section //-->
+
+        </div> <!--// /Hidden code //-->
 
         <div id="code" class="col-md-12 col-lg-4 height">
 
+          <!--// mainly displayed navbar //-->
+          <nav class="navbar navbar-inverse navbar-fixed-bottom">
+            <div class="container-fluid">
+
+              <!--// Hidden lg //-->
+              <ul class="nav navbar-nav navbar-left hidden-lg">
+                <li id="changeMode"><a ><i class="fa fa-paint-brush fa-2x"></i></a></i></li>
+              </ul>
+
+              <ul class="nav navbar-nav navbar-right">
+                <li id="trash"><a ><i class="fa fa-trash fa-2x" aria-hidden="true"></i></a></li>
+                <li id="play" class="active"><a ><i class="fa fa-play fa-2x"></i></a></li>
+              </ul>
+
+              <!--// Only lg, hide code panel //-->
+              <ul class="nav navbar-nav navbar-left hidden-xs hidden-sm hidden-md">
+
+                <li id="toggle-code"><a> <i class="fa fa-arrow-left fa-2x"></i> </a></li>
+
+              </ul>
+
+            </div>
+          </nav>
+
           <div class="code">
-
-            <!--// mainly displayed navbar //-->
-            <nav class="navbar navbar-inverse navbar-fixed-bottom">
-              <div class="container-fluid">
-
-                <!--// Hidden lg //-->
-                <ul class="nav navbar-nav navbar-left hidden-lg">
-                  <li id="changeMode"><a ><i class="fa fa-paint-brush fa-2x"></i></a></i></li>
-                </ul>
-
-                <ul class="nav navbar-nav navbar-right">
-                  <li id="trash"><a ><i class="fa fa-trash fa-2x" aria-hidden="true"></i></a></li>
-                  <li id="play" class="active"><a ><i class="fa fa-play fa-2x"></i></a></li>
-                </ul>
-
-              </div>
-            </nav>
 
             <!--// textarea used to create CodeMirror //-->
             <textarea id="editor"></textarea>

--- a/js/app.js
+++ b/js/app.js
@@ -130,12 +130,26 @@ app.registerEvents = function() {
     app.editor.clearHistory();
   });
 
-  // toggles the notDisplayed class on click.
+  // Toggles the notDisplayed class on click.
   // (Switch from code to output and back on smaller displays)
   $(document).on('click', '#changeMode',  function() {
     $('#code').toggleClass('notDisplayed');
     $('#result').toggleClass('notDisplayed');
   });
+
+  // Hides the code bit on click.
+  // (On lg screens only)
+  $(document).on('click', '#toggle-code', function() {
+    // resizing the result bit
+    $('#result').toggleClass('col-lg-8');
+    $('#result').toggleClass('col-lg-11');
+
+    // Hiding/showing the code bit.
+    $('#code').toggleClass('hideOnLg');
+
+    // Hiding/showing the alternative nav (hidden by default)
+    $('#hidden-code').toggleClass('hideOnLg');
+  })
 
   /*Menu-toggle*/
   $(document).on('click','.menu', function(e) {


### PR DESCRIPTION
This update allows the user to hide the panel containing their code.
This is to make the output field a little bigger.

This option is only needed on lg screens since all the other smaller
screens already show only one of the two (code or output).
