### PR TITLE
fixed the width of side icon nav

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -31,6 +31,8 @@ body, html {
 
 #hidden-code {
   background-color: #2c3e50;
+  width: 60px;
+  float: left;
 }
 #hidden-code .navbar {
   background-color: #2c3e50;
@@ -43,7 +45,10 @@ body, html {
 #hidden-code .nav>li {
   float: none;
 }
-
+.outputLarge {
+  margin-left: 60px;
+  float: none;
+}
 .table-cell {
   display: table-cell;
 }

--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
       <div class="row height">
 
         <!--// This is displayed when the code editor is hidden //-->
-        <div id="hidden-code" class="col-lg-1 height notDisplayed hideOnLg">
+        <div id="hidden-code" class="height notDisplayed hideOnLg">
 
           <!--// Fixed to top navbar //-->
           <nav class="navbar navbar-nav navbar-inverse">

--- a/js/app.js
+++ b/js/app.js
@@ -142,7 +142,7 @@ app.registerEvents = function() {
   $(document).on('click', '#toggle-code', function() {
     // resizing the result bit
     $('#result').toggleClass('col-lg-8');
-    $('#result').toggleClass('col-lg-11');
+    $('#result').toggleClass('outputLarge');
 
     // Hiding/showing the code bit.
     $('#code').toggleClass('hideOnLg');


### PR DESCRIPTION
Playing around with the css I figured out a way to fix the weird “too
wide” display of the side icon navbar.

It now has a permanent width of 60px instead of a percentage.
