### PR TITLE
fixed empty screen at 1200px

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -185,7 +185,7 @@ body, html {
       position: static;
     }
   }
-  @media screen and (max-width: 1200px) {
+  @media screen and (max-width: 1199px) {
     .notDisplayed {
       display: none !important;
     }


### PR DESCRIPTION
At exactly 1200px the screen was empty except for the top navbar and
the code editor (if it was being displayed)

Setting the breakpoint 1px earlier overlaps 2 breakpoints, fixing this
issue.
