### PR TITLE
fixed menu-icon placement

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -19,9 +19,17 @@ body, html {
   border-radius: 0px;
   position: absolute;
 }
-
+#top-navbar {
+  max-height: 51px;
+}
 .menu {
-  font-size: 1.5em;
+  font-size: 32px;
+  padding-top: 9px!important;
+  padding-bottom: 9px!important;
+}
+#menu {
+  margin-left: -15px;
+  margin-right: 10px;
 }
 
 .code {

--- a/index.html
+++ b/index.html
@@ -46,10 +46,11 @@
   </head>
   <body>
 
-    <nav class="navbar navbar-inverse navbar-fixed-top">
+    <nav class="navbar navbar-inverse navbar-fixed-top" id="top-navbar">
+
       <div class="container-fluid">
 
-        <ul class="nav navbar-nav">
+        <ul class="nav navbar-nav" id="menu">
           <li>
             <a class="menu" >
 


### PR DESCRIPTION
The icon placement and size looked a bit weird when you toggled the
code section so that the icon-menu showed.

I made the menu-icon the same size as all the other icon-buttons and
made sure it was nicely aligned with the icon-menu.

Note: this issue was only on lg displays since all the other displays
don’t have the icon-menu feature.
